### PR TITLE
Enable third-party cookies in WebView

### DIFF
--- a/app/src/main/java/com/foss/aihub/ui/webview/WebViewUtils.kt
+++ b/app/src/main/java/com/foss/aihub/ui/webview/WebViewUtils.kt
@@ -32,7 +32,7 @@ fun createWebViewForService(
     return WebView(context).apply {
         val cookieManager = CookieManager.getInstance()
         cookieManager.setAcceptCookie(true)
-        cookieManager.setAcceptThirdPartyCookies(this, false)
+        cookieManager.setAcceptThirdPartyCookies(this, true)
 
         layoutParams = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT


### PR DESCRIPTION
- cookieManager.setAcceptThirdPartyCookies chancge to true

this should solve the log-out problem, with the actual blocklist we have, this could be set to true without any privacy risk, but in future a better aproach will be a sandbox/profile for every service, for much better security and privacy, will isolate cookies files so no need of worries about third party cookies