### PR TITLE
Add Clear Site Data and drawer search/filters

### DIFF
--- a/app/src/main/java/com/foss/aihub/ui/components/AppBar.kt
+++ b/app/src/main/java/com/foss/aihub/ui/components/AppBar.kt
@@ -30,8 +30,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Apps
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.DeleteSweep
 import androidx.compose.material.icons.rounded.Menu
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.BottomSheetDefaults
@@ -72,6 +75,7 @@ fun AiHubAppBar(
     selectedService: AiService,
     onMenuClick: () -> Unit,
     onSettingsClick: () -> Unit,
+    onClearSiteData: () -> Unit,
     loadedServiceIds: Set<String>,
     allServices: List<AiService>,
     onServiceSelected: (AiService) -> Unit
@@ -80,6 +84,7 @@ fun AiHubAppBar(
         skipPartiallyExpanded = false, confirmValueChange = { true })
     val scope = rememberCoroutineScope()
     var showBottomSheet by remember { mutableStateOf(false) }
+    var showClearDataDialog by remember { mutableStateOf(false) }
 
     TopAppBar(
         title = {
@@ -139,6 +144,18 @@ fun AiHubAppBar(
                     modifier = Modifier.size(24.dp)
                 )
             }
+        }
+
+        IconButton(
+            onClick = { showClearDataDialog = true }, modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape)
+        ) {
+            Icon(
+                Icons.Rounded.DeleteSweep,
+                contentDescription = "Clear Site Data",
+                modifier = Modifier.size(24.dp)
+            )
         }
 
         IconButton(
@@ -259,6 +276,45 @@ fun AiHubAppBar(
                 }
             }
         }
+    }
+
+    if (showClearDataDialog) {
+        AlertDialog(
+            onDismissRequest = { showClearDataDialog = false },
+            title = {
+                Text(
+                    text = "Clear Site Data",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.SemiBold
+                )
+            },
+            text = {
+                Text(
+                    text = "This will clear cookies, local storage, and session data only for ${selectedService.name}. You may be logged out of this site.\n\nOther services will not be affected.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showClearDataDialog = false
+                    onClearSiteData()
+                }) {
+                    Text(
+                        text = "Clear",
+                        color = MaterialTheme.colorScheme.error,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearDataDialog = false }) {
+                    Text(text = "Cancel")
+                }
+            },
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            titleContentColor = MaterialTheme.colorScheme.onSurface,
+            textContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 

--- a/app/src/main/java/com/foss/aihub/ui/components/NavigationDrawerContent.kt
+++ b/app/src/main/java/com/foss/aihub/ui/components/NavigationDrawerContent.kt
@@ -1,8 +1,14 @@
 package com.foss.aihub.ui.components
 
 import android.content.Intent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,17 +32,27 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.FilterList
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -76,10 +92,27 @@ fun DrawerContent(
     val colorScheme = MaterialTheme.colorScheme
     val scope = rememberCoroutineScope()
     var isUpdatingDomainRules by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
+    var showFilters by remember { mutableStateOf(false) }
+    var selectedCategories by remember { mutableStateOf(emptySet<String>()) }
 
     val orderedEnabledServices = remember(enabledServices, serviceOrder, aiServices.toList()) {
         serviceOrder.filter { it in enabledServices }
             .mapNotNull { id -> aiServices.find { it.id == id } }
+    }
+
+    val availableCategories by derivedStateOf {
+        orderedEnabledServices.map { it.category }.distinct().sorted()
+    }
+
+    val filteredServices by derivedStateOf {
+        orderedEnabledServices.filter { service ->
+            val matchesSearch = searchQuery.isBlank() ||
+                    service.name.contains(searchQuery, ignoreCase = true)
+            val matchesCategory = selectedCategories.isEmpty() ||
+                    service.category in selectedCategories
+            matchesSearch && matchesCategory
+        }
     }
 
     Surface(
@@ -158,12 +191,135 @@ fun DrawerContent(
                     }
                 }
 
-                Text(
-                    text = "AI Assistants",
-                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-                    color = colorScheme.onSurface,
-                    modifier = Modifier.padding(start = 24.dp, top = 16.dp, bottom = 12.dp)
-                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 24.dp, end = 16.dp, top = 16.dp, bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "AI Assistants",
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                        color = colorScheme.onSurface
+                    )
+                    IconButton(
+                        onClick = {
+                            showFilters = !showFilters
+                            if (!showFilters) {
+                                selectedCategories = emptySet()
+                                searchQuery = ""
+                            }
+                        },
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            imageVector = if (showFilters) Icons.Rounded.Close else Icons.Rounded.FilterList,
+                            contentDescription = "Filter",
+                            tint = if (showFilters || selectedCategories.isNotEmpty())
+                                colorScheme.primary else colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(22.dp)
+                        )
+                    }
+                }
+
+                AnimatedVisibility(
+                    visible = showFilters,
+                    enter = expandVertically() + fadeIn(),
+                    exit = shrinkVertically() + fadeOut()
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                    ) {
+                        OutlinedTextField(
+                            value = searchQuery,
+                            onValueChange = { searchQuery = it },
+                            placeholder = {
+                                Text(
+                                    text = "Search services...",
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Rounded.Search,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(20.dp),
+                                    tint = colorScheme.onSurfaceVariant
+                                )
+                            },
+                            trailingIcon = {
+                                if (searchQuery.isNotEmpty()) {
+                                    IconButton(
+                                        onClick = { searchQuery = "" },
+                                        modifier = Modifier.size(32.dp)
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Close,
+                                            contentDescription = "Clear",
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    }
+                                }
+                            },
+                            singleLine = true,
+                            shape = RoundedCornerShape(16.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = colorScheme.primary,
+                                unfocusedBorderColor = colorScheme.outlineVariant,
+                                focusedContainerColor = colorScheme.surfaceContainerLow,
+                                unfocusedContainerColor = colorScheme.surfaceContainerLow
+                            ),
+                            textStyle = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .horizontalScroll(rememberScrollState()),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            availableCategories.forEach { category ->
+                                val isSelected = category in selectedCategories
+                                FilterChip(
+                                    selected = isSelected,
+                                    onClick = {
+                                        selectedCategories = if (isSelected) {
+                                            selectedCategories - category
+                                        } else {
+                                            selectedCategories + category
+                                        }
+                                    },
+                                    label = {
+                                        Text(
+                                            text = category,
+                                            style = MaterialTheme.typography.labelMedium,
+                                            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+                                        )
+                                    },
+                                    colors = FilterChipDefaults.filterChipColors(
+                                        selectedContainerColor = colorScheme.primaryContainer,
+                                        selectedLabelColor = colorScheme.onPrimaryContainer
+                                    ),
+                                    border = FilterChipDefaults.filterChipBorder(
+                                        borderColor = colorScheme.outlineVariant,
+                                        selectedBorderColor = colorScheme.primary.copy(alpha = 0.3f),
+                                        enabled = true,
+                                        selected = isSelected
+                                    ),
+                                    shape = RoundedCornerShape(12.dp)
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
 
                 LazyColumn(
                     modifier = Modifier
@@ -173,7 +329,7 @@ fun DrawerContent(
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                     contentPadding = PaddingValues(bottom = 20.dp)
                 ) {
-                    items(orderedEnabledServices) { service ->
+                    items(filteredServices, key = { it.id }) { service ->
                         val state = webViewStates[service.id] ?: WebViewState.IDLE
                         Md3ServiceCard(
                             service = service,

--- a/app/src/main/java/com/foss/aihub/ui/screens/AiHubScreen.kt
+++ b/app/src/main/java/com/foss/aihub/ui/screens/AiHubScreen.kt
@@ -266,6 +266,58 @@ fun AiHubApp(activity: MainActivity) {
                         }
                     },
                     onSettingsClick = { showSettingsScreen = true },
+                    onClearSiteData = {
+                        val serviceId = selectedService.id
+                        val webView = webViews[serviceId]
+                        if (webView != null) {
+                            val currentUrl = webView.url ?: selectedService.url
+                            val domain = try {
+                                android.net.Uri.parse(currentUrl).host ?: ""
+                            } catch (_: Exception) { "" }
+
+                            // Clear cookies for this domain only
+                            val cookieManager = android.webkit.CookieManager.getInstance()
+                            val cookies = cookieManager.getCookie(currentUrl)
+                            if (cookies != null) {
+                                val cookieNames = cookies.split(";").mapNotNull { cookie ->
+                                    cookie.trim().split("=").firstOrNull()?.trim()
+                                }
+                                for (name in cookieNames) {
+                                    cookieManager.setCookie(currentUrl, "$name=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/")
+                                    cookieManager.setCookie(currentUrl, "$name=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Domain=$domain")
+                                }
+                                cookieManager.flush()
+                            }
+
+                            // Clear localStorage and sessionStorage via JavaScript
+                            webView.evaluateJavascript(
+                                "try { localStorage.clear(); sessionStorage.clear(); } catch(e) {}",
+                                null
+                            )
+
+                            // Clear WebView cache for this specific view and reload
+                            webView.clearCache(true)
+                            webView.clearFormData()
+                            webView.clearHistory()
+
+                            // Reload the tab
+                            updateServiceState(serviceId) { state ->
+                                state.copy(
+                                    webViewState = WebViewState.LOADING,
+                                    isLoading = true,
+                                    error = null,
+                                    progress = 0
+                                )
+                            }
+                            webView.loadUrl(selectedService.url)
+
+                            Toast.makeText(
+                                context,
+                                "Site data cleared for ${selectedService.name}",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    },
                     loadedServiceIds = webViews.keys,
                     allServices = aiServices,
                     onServiceSelected = { service ->


### PR DESCRIPTION
Add a "Clear Site Data" action to the app bar: new DeleteSweep icon opens a confirmation AlertDialog and exposes onClearSiteData callback. Implement onClearSiteData in AiHubScreen to clear cookies for the current domain, run JavaScript to clear localStorage/sessionStorage, clear WebView cache/form/history, reload the tab and show a toast.

Enhance NavigationDrawerContent with a filter/search UI: a toggleable filter panel with animated visibility, an outlined search field, horizontal FilterChips for service categories, and derived-state filtering (search + category) applied to the service list. Also include related UI and import adjustments.