### PR TITLE
Add service favorites UI

### DIFF
--- a/app/src/main/java/com/foss/aihub/models/AiService.kt
+++ b/app/src/main/java/com/foss/aihub/models/AiService.kt
@@ -22,5 +22,6 @@ data class AppSettings(
     var thirdPartyCookies: Boolean = false,
     var maxKeepAlive: Int = 5,
     var enabledServices: Set<String> = emptySet(),
-    var serviceOrder: List<String> = emptyList()
+    var serviceOrder: List<String> = emptyList(),
+    var favoriteServices: Set<String> = emptySet()
 )

--- a/app/src/main/java/com/foss/aihub/ui/components/NavigationDrawerContent.kt
+++ b/app/src/main/java/com/foss/aihub/ui/components/NavigationDrawerContent.kt
@@ -31,11 +31,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.FilterList
 import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
@@ -86,6 +86,8 @@ fun DrawerContent(
     webViewStates: Map<String, WebViewState>,
     enabledServices: Set<String>,
     serviceOrder: List<String>,
+    favoriteServices: Set<String>,
+    onToggleFavorite: (String) -> Unit,
     snackbarHostState: SnackbarHostState
 ) {
     val context = LocalContext.current
@@ -127,7 +129,6 @@ fun DrawerContent(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
                     .navigationBarsPadding()
             ) {
                 Box(
@@ -321,6 +322,14 @@ fun DrawerContent(
                     }
                 }
 
+                val favoriteFilteredServices by derivedStateOf {
+                    filteredServices.filter { it.id in favoriteServices }
+                }
+
+                val nonFavoriteFilteredServices by derivedStateOf {
+                    filteredServices.filter { it.id !in favoriteServices }
+                }
+
                 LazyColumn(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -329,20 +338,79 @@ fun DrawerContent(
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                     contentPadding = PaddingValues(bottom = 20.dp)
                 ) {
-                    items(filteredServices, key = { it.id }) { service ->
+                    if (favoriteFilteredServices.isNotEmpty()) {
+                        item(key = "favorites_header") {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 2.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Star,
+                                    contentDescription = null,
+                                    tint = Color(0xFFFFB300),
+                                    modifier = Modifier.size(16.dp)
+                                )
+                                Text(
+                                    text = "Favorites",
+                                    style = MaterialTheme.typography.labelLarge.copy(
+                                        fontWeight = FontWeight.SemiBold
+                                    ),
+                                    color = colorScheme.onSurface
+                                )
+                            }
+                        }
+
+                        items(favoriteFilteredServices, key = { "fav_${it.id}" }) { service ->
+                            val state = webViewStates[service.id] ?: WebViewState.IDLE
+                            Md3ServiceCard(
+                                service = service,
+                                serviceColor = service.accentColor,
+                                isSelected = selectedService.id == service.id,
+                                state = state,
+                                isFavorite = true,
+                                onFavoriteToggle = { onToggleFavorite(service.id) },
+                                onClick = {
+                                    if (selectedService.id == service.id) {
+                                        onServiceReload(service)
+                                    } else {
+                                        onServiceSelected(service)
+                                    }
+                                }
+                            )
+                        }
+
+                        if (nonFavoriteFilteredServices.isNotEmpty()) {
+                            item(key = "all_header") {
+                                Text(
+                                    text = "All Services",
+                                    style = MaterialTheme.typography.labelLarge.copy(
+                                        fontWeight = FontWeight.SemiBold
+                                    ),
+                                    color = colorScheme.onSurface,
+                                    modifier = Modifier.padding(start = 4.dp, top = 8.dp, bottom = 2.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    items(nonFavoriteFilteredServices, key = { it.id }) { service ->
                         val state = webViewStates[service.id] ?: WebViewState.IDLE
                         Md3ServiceCard(
                             service = service,
                             serviceColor = service.accentColor,
                             isSelected = selectedService.id == service.id,
                             state = state,
+                            isFavorite = false,
+                            onFavoriteToggle = { onToggleFavorite(service.id) },
                             onClick = {
                                 if (selectedService.id == service.id) {
                                     onServiceReload(service)
                                 } else {
                                     onServiceSelected(service)
                                 }
-                            })
+                            }
+                        )
                     }
                 }
 

--- a/app/src/main/java/com/foss/aihub/ui/components/ServiceCard.kt
+++ b/app/src/main/java/com/foss/aihub/ui/components/ServiceCard.kt
@@ -1,25 +1,33 @@
 package com.foss.aihub.ui.components
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Error
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material.icons.rounded.StarOutline
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -35,6 +43,8 @@ fun Md3ServiceCard(
     serviceColor: Color,
     isSelected: Boolean,
     state: WebViewState,
+    isFavorite: Boolean,
+    onFavoriteToggle: () -> Unit,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -70,7 +80,7 @@ fun Md3ServiceCard(
         Row(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(start = 16.dp, end = 4.dp, top = 12.dp, bottom = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(0.dp)
         ) {
@@ -186,6 +196,26 @@ fun Md3ServiceCard(
                         modifier = Modifier.weight(1f)
                     )
                 }
+            }
+
+            Spacer(modifier = Modifier.width(4.dp))
+
+            val starColor by animateColorAsState(
+                targetValue = if (isFavorite) Color(0xFFFFB300) else colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                animationSpec = tween(durationMillis = 250),
+                label = "starColor"
+            )
+
+            IconButton(
+                onClick = onFavoriteToggle,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = if (isFavorite) Icons.Rounded.Star else Icons.Rounded.StarOutline,
+                    contentDescription = if (isFavorite) "Remove from favorites" else "Add to favorites",
+                    tint = starColor,
+                    modifier = Modifier.size(20.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/foss/aihub/ui/screens/AiHubScreen.kt
+++ b/app/src/main/java/com/foss/aihub/ui/screens/AiHubScreen.kt
@@ -250,6 +250,16 @@ fun AiHubApp(activity: MainActivity) {
                 webViewStates = serviceStates.mapValues { it.value.webViewState },
                 enabledServices = settings.enabledServices,
                 serviceOrder = settings.serviceOrder,
+                favoriteServices = settings.favoriteServices,
+                onToggleFavorite = { serviceId ->
+                    settingsManager.updateSettings { current ->
+                        current.favoriteServices = if (serviceId in current.favoriteServices) {
+                            current.favoriteServices - serviceId
+                        } else {
+                            current.favoriteServices + serviceId
+                        }
+                    }
+                },
                 snackbarHostState = snackbarHostState
             )
         }) {

--- a/app/src/main/java/com/foss/aihub/utils/SharedPreferencesHelper.kt
+++ b/app/src/main/java/com/foss/aihub/utils/SharedPreferencesHelper.kt
@@ -164,7 +164,8 @@ class SettingsManager(context: Context) {
             desktopView = sharedPref.getBoolean("desktopView", false),
             thirdPartyCookies = sharedPref.getBoolean("thirdPartyCookies", false),
             enabledServices = loadEnabledServices(),
-            serviceOrder = loadServiceOrder()
+            serviceOrder = loadServiceOrder(),
+            favoriteServices = loadFavoriteServices()
         )
     }
 
@@ -180,6 +181,7 @@ class SettingsManager(context: Context) {
             putBoolean("thirdPartyCookies", settings.thirdPartyCookies)
             saveEnabledServices(settings.enabledServices)
             saveServiceOrder(settings.serviceOrder)
+            saveFavoriteServices(settings.favoriteServices)
         }
     }
 
@@ -211,6 +213,21 @@ class SettingsManager(context: Context) {
     private fun saveServiceOrder(order: List<String>) {
         val json = gson.toJson(order)
         sharedPref.edit { putString("serviceOrder", json) }
+    }
+
+    private fun loadFavoriteServices(): Set<String> {
+        val json = sharedPref.getString("favoriteServices", null)
+        return if (json.isNullOrEmpty()) {
+            emptySet()
+        } else {
+            val type = object : TypeToken<Set<String>>() {}.type
+            gson.fromJson(json, type)
+        }
+    }
+
+    private fun saveFavoriteServices(favorites: Set<String>) {
+        val json = gson.toJson(favorites)
+        sharedPref.edit { putString("favoriteServices", json) }
     }
 
     fun saveLastOpenedService(serviceId: String) {


### PR DESCRIPTION
Introduce favorite services support across the app: add favoriteServices to AppSettings, persist/load favorites in SettingsManager (SharedPreferences) with new helper methods, and wire a toggle handler in AiHubScreen to update settings. UI changes: add a star IconButton with animated color to Md3ServiceCard, adjust layout/padding, and update the navigation drawer to show a "Favorites" section above other services and pass favorite toggles to the card