### PR TITLE
Add and update pt-rBR string resources

### DIFF
--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,9 +1,12 @@
 <resources>
+    <!-- App Info -->
     <string name="app_name" translatable="false">AI Hub</string>
     <string name="app_author" translatable="false">Silent Coder</string>
     <string name="matrix" translatable="false">Matrix</string>
     <string name="app_logo_description">Logo do AI Hub</string>
     <string name="app_tagline">Sua Coleção de Companheiros de IA</string>
+
+    <!-- Actions -->
     <string name="action_back">Voltar</string>
     <string name="action_cancel">Cancelar</string>
     <string name="action_clear">Limpar</string>
@@ -18,7 +21,9 @@
     <string name="action_copy">Copiar</string>
     <string name="action_copy_link">Copiar link</string>
     <string name="action_delete">Excluir</string>
+    <string name="action_discard">Descartar</string>
     <string name="action_filter">Filtrar</string>
+    <string name="action_later">Mais tarde</string>
     <string name="action_leave">Sair</string>
     <string name="action_more_options">Mais opções</string>
     <string name="action_move_down">Mover para baixo</string>
@@ -30,6 +35,7 @@
     <string name="action_remove_service">Fechar serviço</string>
     <string name="action_restart">Reiniciar</string>
     <string name="action_retry">Tentar novamente</string>
+    <string name="action_save">Salvar</string>
     <string name="action_search">Pesquisar</string>
     <string name="action_share">Compartilhar</string>
     <string name="action_share_link">Compartilhar link</string>
@@ -38,37 +44,61 @@
     <string name="action_stay">Ficar</string>
     <string name="action_update">Atualizar</string>
     <string name="action_update_services">Atualizar IA e serviços</string>
+
+    <!-- Copy & Share Descriptions -->
     <string name="copy_link_description">Copiar link para a área de transferência</string>
     <string name="open_in_browser_description">Abrir em navegador externo</string>
     <string name="share_link_description">Compartilhar via outros aplicativos</string>
+
+    <!-- Error Messages -->
     <string name="error_desc_http_error">%1$s retornou erro %2$d</string>
     <string name="error_desc_no_connection">Não foi possível alcançar %1$s. Verifique sua conexão com a internet.</string>
     <string name="error_desc_ssl_issue">Não foi possível conectar com segurança a %1$s. Possível problema de certificado ou segurança.</string>
     <string name="error_generic_message">Ocorreu um erro inesperado. Por favor, tente novamente.</string>
     <string name="error_generic_title">Algo deu errado</string>
+    <string name="error_no_connection_message">Não é possível conectar ao servidor. Verifique sua conexão com a internet.</string>
+    <string name="error_request_failed_message">A solicitação falhou. Erro HTTP %1$d</string>
+    <string name="error_seriliaziation_message">Dados inesperados recebidos do servidor. Por favor, tente novamente mais tarde.</string>
     <string name="error_service_info_format">Serviço: %1$s • Código: %2$d</string>
+    <string name="error_something_went_wrong_message">Algo deu errado. Por favor, tente novamente.</string>
+    <string name="error_timeout_message">A requisição expirou. Por favor, verifique sua internet e tente novamente.</string>
     <string name="error_title_no_connection">Sem Conexão</string>
     <string name="error_title_security_issue">Problema de Segurança</string>
     <string name="error_title_server_error">Erro no Servidor</string>
     <string name="error_unknown">Erro desconhecido</string>
+
+    <!-- Labels -->
     <string name="hint_search_services">Pesquisar serviços…</string>
     <string name="label_active">Ativo</string>
+    <string name="label_added">Adicionado</string>
+    <string name="label_ai_services">Serviços de IA</string>
     <string name="label_alert">Alerta</string>
+    <string name="label_always_blocked_domains">Domínios Sempre Bloqueados</string>
     <string name="label_before_leave">Antes de Sair</string>
     <string name="label_blocked_url">URL Bloqueada</string>
+    <string name="label_changed">Alterado</string>
+    <string name="label_changes_summary">%1$d alterações em 5 categorias</string>
+    <string name="label_collapse">Recolher</string>
+    <string name="label_common_auth_domains">Domínios de Autenticação Comuns</string>
     <string name="label_confirm">Confirmar</string>
     <string name="label_connecting">Conectando…</string>
     <string name="label_connection_failed">Falha na conexão</string>
     <string name="label_contributors">Contribuidores</string>
+    <string name="label_custom_css" translatable="false">CSS</string>
+    <string name="label_custom_js" translatable="false">JavaScript</string>
     <string name="label_default_ai">Padrão</string>
     <string name="label_details">Detalhes</string>
     <string name="label_email">E-mail</string>
     <string name="label_error">Erro</string>
+    <string name="label_expand">Expandir</string>
     <string name="label_font_size_large">Grande</string>
     <string name="label_font_size_medium">Médio</string>
     <string name="label_font_size_small">Pequeno</string>
     <string name="label_font_size_xlarge">Extra grande</string>
     <string name="label_font_size_xsmall">Extra pequeno</string>
+    <string name="label_frequency_1_day">Diariamente</string>
+    <string name="label_frequency_1_week">Semanalmente</string>
+    <string name="label_frequency_3_days">A cada 3 dias</string>
     <string name="label_image">Imagem</string>
     <string name="label_image_link">Link da imagem</string>
     <string name="label_just_a_moment">Só um momento…</string>
@@ -86,13 +116,21 @@
     <string name="label_prompt">Prompt</string>
     <string name="label_ready">Pronto</string>
     <string name="label_refreshing">Atualizando…</string>
+    <string name="label_removed">Removido</string>
     <string name="label_select">Selecionar</string>
     <string name="label_selected">Selecionado</string>
     <string name="label_service">Serviço</string>
+    <string name="label_service_domains">Domínios de Serviço</string>
     <string name="label_service_title">Título do serviço</string>
     <string name="label_something_went_wrong">Algo deu errado</string>
+    <string name="label_tracking_parameters">Parâmetros de Rastreamento</string>
     <string name="label_unknown_error">Erro desconhecido</string>
+    <string name="label_unsaved_changes">Alterações Não Salvas</string>
+    <string name="label_update_summary">Resumo da atualização</string>
+    <string name="label_update_title">Atualização Disponível</string>
     <string name="label_url">URL</string>
+
+    <!-- Messages -->
     <string name="msg_add_to_fav">Adicionar aos favoritos</string>
     <string name="msg_ai_update_success">Serviços de IA atualizados</string>
     <string name="msg_all_data_cleared">Todos os dados limpos</string>
@@ -100,10 +138,12 @@
     <string name="msg_cache_cleared">Cache limpo</string>
     <string name="msg_camera_and_microphone_enabled">Câmera e microfone ativados</string>
     <string name="msg_camera_enabled">Câmera ativada</string>
+    <string name="msg_changes_saved">Alterações salvas</string>
     <string name="msg_clear_all_cache_confirmation">Remove arquivos temporários da web.\nPode desconectar você de sites.</string>
     <string name="msg_clear_all_data_confirmation">Exclui cache, cookies, histórico, logins…\nIsso não pode ser desfeito.</string>
     <string name="msg_clear_site_data_warning">Isso limpará cookies, armazenamento local e dados de sessão apenas para %1$s.\nVocê pode ser desconectado deste site.\n\nOutros serviços não serão afetados.</string>
     <string name="msg_copy_description">Copie estes detalhes se precisar relatar este problema</string>
+    <string name="msg_custom_injection">Nota: As alterações são aplicadas após recarregar. Adicione JavaScript/CSS personalizado injetado em cada serviço.</string>
     <string name="msg_domain_update_success">Regras de domínio atualizadas</string>
     <string name="msg_download_failed">Falha no download</string>
     <string name="msg_dowload_complete">Download concluído: %1$s</string>
@@ -116,6 +156,7 @@
     <string name="msg_no_ai_services_enabled">Nenhum serviço de IA ativado</string>
     <string name="msg_page_blocked_description">Esta página não pode ser carregada devido às configurações de segurança.</string>
     <string name="msg_permission_denied">Permissão negada</string>
+    <string name="msg_press_again">Pressione voltar novamente para sair</string>
     <string name="msg_processing_blob">Processando download de blob…</string>
     <string name="msg_remove_from_fav">Remover dos favoritos</string>
     <string name="msg_saved">Salvo: %1$s</string>
@@ -123,28 +164,40 @@
     <string name="msg_share_app">Confira o %1$s — uma coleção de código aberto dos seus assistentes de IA favoritos!\n\nBaixe o app: %2$s</string>
     <string name="msg_site_data_cleared">Dados do site limpos para %1$s</string>
     <string name="msg_theme_switch_disabled">A troca de tema está temporariamente desativada (não está funcionando corretamente)</string>
+    <string name="msg_unsaved_changes">Você tem alterações não salvas. Deseja salvá-las antes de sair?</string>
     <string name="msg_unsupported_scheme">Esquema de download não suportado: %1$s</string>
     <string name="msg_update_all_success">Regras de domínio e serviços de IA atualizados</string>
     <string name="msg_update_failed">Falha na atualização – verifique a conexão</string>
+    <string name="msg_write_css_here">Escreva seu CSS personalizado aqui…</string>
+    <string name="msg_write_js_here">Escreva seu JavaScript personalizado aqui…</string>
+
+    <!-- Sections -->
     <string name="section_about">Sobre</string>
+    <string name="section_cloud_updates">Atualizações na Nuvem</string>
     <string name="section_performance">Desempenho</string>
     <string name="section_preferences">Preferências</string>
     <string name="section_security_privacy">Segurança e Privacidade</string>
     <string name="section_storage">Armazenamento</string>
     <string name="section_webview">WebView</string>
+
+    <!-- Settings -->
     <string name="setting_block_trackers_ads">Bloquear rastreadores e anúncios</string>
     <string name="setting_block_trackers_ads_description">Recomendado para privacidade</string>
+    <string name="setting_custom_injection">Injeção de JS/CSS Personalizado</string>
+    <string name="setting_custom_injection_description">Injetar JavaScript/CSS personalizado em cada serviço</string>
     <string name="setting_default_ai">Assistente de IA Padrão</string>
     <string name="setting_default_ai_description">Exibido quando o app inicia</string>
     <string name="setting_desktop_mode">Modo desktop</string>
     <string name="setting_desktop_mode_description">Solicitar versões desktop de sites</string>
+    <string name="setting_enable_cloud_updates">Verificar atualizações na nuvem</string>
+    <string name="setting_enable_cloud_updates_description">Verificar automaticamente atualizações de dados na nuvem</string>
     <string name="setting_font_size">Tamanho da fonte</string>
     <string name="setting_font_size_description">Alterar o tamanho do texto</string>
     <string name="setting_manage_ai_services">Gerenciar Serviços de IA</string>
     <string name="setting_manage_ai_services_description">Ativar, desativar e reordenar serviços de IA</string>
     <string name="setting_memory_management">Gerenciamento de Memória</string>
     <string name="setting_memory_management_description">Controlar o carregamento simultâneo de IA</string>
-    <string name="setting_pinch_to_zoom">Pincer para ampliar</string>
+    <string name="setting_pinch_to_zoom">Pinçar para ampliar</string>
     <string name="setting_pinch_to_zoom_description">Ampliar e reduzir páginas da web</string>
     <string name="setting_restore_last_ai">Carregar última IA aberta</string>
     <string name="setting_restore_last_ai_description">Reabrir o último assistente usado ao iniciar</string>
@@ -152,12 +205,20 @@
     <string name="setting_theme_description">Escolha entre padrão do sistema, claro ou escuro</string>
     <string name="setting_third_party_cookies">Permitir cookies de terceiros</string>
     <string name="setting_third_party_cookies_description">Pode ser necessário para alguns logins</string>
+    <string name="setting_update_frequency">Frequência de atualização</string>
+    <string name="setting_update_frequency_description">Com que frequência verificar se há atualizações</string>
+
+    <!-- Status & Tabs -->
     <string name="status_updating">Atualizando…</string>
     <string name="tab_all_services">Todos os Serviços</string>
     <string name="tab_favorites">Favoritos</string>
+
+    <!-- Theme Options -->
     <string name="theme_auto">Automático</string>
     <string name="theme_dark">Escuro</string>
     <string name="theme_light">Claro</string>
+
+    <!-- Titles -->
     <string name="title_active_ai_services">Serviços de IA Ativos</string>
     <string name="title_ai_assistants">Assistentes de IA</string>
     <string name="title_settings">Configurações</string>


### PR DESCRIPTION
Expand Brazilian Portuguese translations: add grouped comments and many new strings for actions, errors, labels, messages, sections, settings, status/tabs, theme options and titles. Introduce custom injection, cloud update and update-frequency strings, several user-facing messages (unsaved changes, press again, changes saved), and additional error/timing descriptions. Also fix a minor spelling/localization ("Pinçar para ampliar"). These additions provide more complete localization and UI copy for pt-rBR.